### PR TITLE
Suggestion: response include json marshal err instead silence it

### DIFF
--- a/response.go
+++ b/response.go
@@ -104,7 +104,6 @@ type Response interface {
 	Write(w http.ResponseWriter, request *http.Request)
 }
 
-
 /*
 response is implementation of Response interface
 */
@@ -291,6 +290,8 @@ func (r *response) GetBytes() (body []byte) {
 		// marshal self
 		if b, err = json.Marshal(r); err == nil {
 			body = b
+		} else {
+			body = []byte(err.Error())
 		}
 	} else {
 		body = []byte(*r.body)


### PR DESCRIPTION
I had an issue http request returns 200 OK but no content, but expect to get some content.
after debugging, found out the MarshalJSON cause this.

`json: error calling MarshalJSON for type *response.response: json: error calling MarshalJSON for type time.Time: Time.MarshalJSON: year outside of range [0,9999]
`
do you think it return this err message than silence can help on trouble shooting?

